### PR TITLE
feat: rename non cat-specific cloud resources

### DIFF
--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Generate Stack ID
         run: |
           RANDOM_STRING=`node -e "const crypto = require('crypto'); process.stdout.write(crypto.randomBytes(Math.ceil(8 * 0.5)).toString('hex').slice(0, 8));"`
-          echo "STACK_NAME=cat-tracker-${{ runner.OS }}-${RANDOM_STRING}" >> $GITHUB_ENV
+          echo "STACK_NAME=nrf-asset-tracker-${{ runner.OS }}-${RANDOM_STRING}" >> $GITHUB_ENV
       - run: aws sts get-caller-identity
       - run: echo "VERSION=${{ github.sha }}" >> $GITHUB_ENV
       - name: Set up stack for End-to-End tests

--- a/cdk/regions.ts
+++ b/cdk/regions.ts
@@ -1,7 +1,7 @@
 /**
  * Note that not all AWS features are available in all AWS regions.
  * Here we keep a list of regions that are known to work with the
- * Cat Tracker implementation.
+ * nRF Asset Tracker implementation.
  */
 export const supportedRegions = [
 	'us-east-1',

--- a/cdk/stacks/CatTracker/lambdas.ts
+++ b/cdk/stacks/CatTracker/lambdas.ts
@@ -31,10 +31,10 @@ export const prepareAssetTrackerLambdas = async ({
 	outDir: string
 	sourceCodeBucketName: string
 }): Promise<PackedLambdas<CatTrackerLambdas>> => {
-	const reporter = ConsoleProgressReporter('Cat Tracker Lambdas')
+	const reporter = ConsoleProgressReporter('nRF Asset Tracker Lambdas')
 	return {
 		layerZipFileName: await packBaseLayer({
-			layerName: 'cat-tracker-layer',
+			layerName: 'asset-tracker-layer',
 			reporter,
 			srcDir: rootDir,
 			outDir,
@@ -50,7 +50,7 @@ export const prepareAssetTrackerLambdas = async ({
 		}),
 		lambdas: await packLayeredLambdas<CatTrackerLambdas>({
 			reporter,
-			id: 'cat-tracker',
+			id: 'asset-tracker',
 			srcDir: rootDir,
 			outDir,
 			Bucket: sourceCodeBucketName,

--- a/cdk/stacks/ContinuousDeployment.ts
+++ b/cdk/stacks/ContinuousDeployment.ts
@@ -144,7 +144,7 @@ export class ContinuousDeploymentStack extends CloudFormation.Stack {
 
 		const project = new CodeBuild.CfnProject(this, 'CodeBuildProject', {
 			name: CONTINUOUS_DEPLOYMENT_STACK_NAME,
-			description: 'Continuous deploys the Cat Tracker resources',
+			description: 'Continuous deploys the nRF Asset Tracker resources',
 			source: {
 				type: 'CODEPIPELINE',
 				buildSpec: 'continuous-deployment.yml',
@@ -294,7 +294,7 @@ export class ContinuousDeploymentStack extends CloudFormation.Stack {
 			).codeBuildProject
 		}
 
-		// Set up the continuous deployment for the Cat Tracker resources.
+		// Set up the continuous deployment for the nRF Asset Tracker resources.
 		// This will also run the deployment of the WebApp and DeviceUI after a deploy
 		// (in case some outputs have changed and need to be made available to the apps).
 

--- a/cdk/stacks/stackName.ts
+++ b/cdk/stacks/stackName.ts
@@ -1,4 +1,4 @@
-const STACK_NAME = process.env.STACK_NAME ?? 'cat-tracker'
+const STACK_NAME = process.env.STACK_NAME ?? 'nrf-asset-tracker'
 export const CORE_STACK_NAME = STACK_NAME
 export const WEBAPP_STACK_NAME = `${STACK_NAME}-webapp`
 export const DEVICEUI_STACK_NAME = `${STACK_NAME}-deviceui`

--- a/cellGeolocation/httpApi/res.ts
+++ b/cellGeolocation/httpApi/res.ts
@@ -15,7 +15,7 @@ export const res = (statusCode: number, options?: { expires: number }) => (
 					new Date().getTime() + options.expires * 1000,
 				).toUTCString(),
 			}),
-			'X-Cat-Tracker-Version': process.env.VERSION ?? 'unknown',
+			'X-asset-tracker-Version': process.env.VERSION ?? 'unknown',
 		},
 		body: JSON.stringify(body),
 	})

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -69,7 +69,7 @@ const assetTrackerCLI = async ({ isCI }: { isCI: boolean }) => {
 		accountId,
 	})
 
-	program.description('Cat Tracker Command Line Interface')
+	program.description('nRF Asset Tracker Command Line Interface')
 
 	const commands = [
 		createCACommand({ certsDir }),
@@ -98,11 +98,11 @@ const assetTrackerCLI = async ({ isCI }: { isCI: boolean }) => {
 			}),
 			cdUpdateTokenCommand(),
 			confirm(
-				'Do you really purge all Cat Tracker buckets?',
+				'Do you really purge all nRF Asset Tracker buckets?',
 				purgeBucketsCommand(),
 			),
 			confirm(
-				'Do you really want to purge all Cat Tracker CAs?',
+				'Do you really want to purge all nRF Asset Tracker CAs?',
 				purgeCAsCommand(),
 			),
 			firmwareCICommand({

--- a/cli/commands/purge-cas.ts
+++ b/cli/commands/purge-cas.ts
@@ -46,7 +46,9 @@ const purgeCACertificate = ({
 			}),
 		)
 	} else {
-		console.error(chalk.yellow.dim(`Not a Cat Tracker CA: ${certificateId}`))
+		console.error(
+			chalk.yellow.dim(`Not a nRF Asset Tracker CA: ${certificateId}`),
+		)
 	}
 }
 
@@ -87,5 +89,5 @@ export const purgeCAsCommand = (): CommandDefinition => ({
 					}),
 		})
 	},
-	help: 'Purges all Cat Tracker CAs',
+	help: 'Purges all nRF Asset Tracker CAs',
 })

--- a/feature-runner/steps/asset-tracker.ts
+++ b/feature-runner/steps/asset-tracker.ts
@@ -89,10 +89,10 @@ export const assetTrackerStepRunners = ({
 	})
 	return [
 		regexMatcher<World>(
-			/^(?:a cat exists|I generate a certificate)(?: for the cat tracker "([^"]+)")?$/,
+			/^(?:I generate a certificate)(?: for the tracker "([^"]+)")?$/,
 		)(async ([deviceId], __, runner) => {
 			const catId = deviceId ?? (await randomWords({ numWords: 3 })).join('-')
-			const prefix = deviceId === undefined ? 'cat' : `cat:${catId}`
+			const prefix = deviceId === undefined ? 'tracker' : `tracker:${catId}`
 			if (runner.store[`${prefix}:id`] === undefined) {
 				await createDeviceCertificate({
 					deviceId: catId,
@@ -127,9 +127,9 @@ export const assetTrackerStepRunners = ({
 			}
 			return runner.store[`${prefix}:id`]
 		}),
-		regexMatcher<World>(/^I connect the cat tracker(?: ([^ ]+))?$/)(
+		regexMatcher<World>(/^I connect the tracker(?: ([^ ]+))?$/)(
 			async ([deviceId], __, runner) => {
-				const catId = deviceId ?? runner.store['cat:id']
+				const catId = deviceId ?? runner.store['tracker:id']
 				await runner.progress('IoT', catId)
 				const deviceFiles = deviceFileLocations({
 					certsDir,
@@ -166,13 +166,13 @@ export const assetTrackerStepRunners = ({
 			},
 		),
 		regexMatcher<World>(
-			/^the cat tracker(?: ([^ ]+))? updates its reported state with$/,
+			/^the tracker(?: ([^ ]+))? updates its reported state with$/,
 		)(async ([deviceId], step, runner) => {
 			if (step.interpolatedArgument === undefined) {
 				throw new Error('Must provide argument!')
 			}
 			const reported = JSON.parse(step.interpolatedArgument)
-			const catId = deviceId ?? runner.store['cat:id']
+			const catId = deviceId ?? runner.store['tracker:id']
 			const connection = shadowOnBroker(catId)
 			const updatePromise = await new Promise((resolve, reject) => {
 				const timeout = setTimeout(reject, 10 * 1000)
@@ -208,9 +208,9 @@ export const assetTrackerStepRunners = ({
 			return await updatePromise
 		}),
 		regexMatcher<World>(
-			/^the cat tracker(?: ([^ ]+))? publishes this message to the topic ([^ ]+)$/,
+			/^the tracker(?: ([^ ]+))? publishes this message to the topic ([^ ]+)$/,
 		)(async ([deviceId, topic], step, runner) => {
-			const catId = deviceId ?? runner.store['cat:id']
+			const catId = deviceId ?? runner.store['tracker:id']
 			if (step.interpolatedArgument === undefined) {
 				throw new Error('Must provide argument!')
 			}
@@ -233,9 +233,9 @@ export const assetTrackerStepRunners = ({
 			return publishPromise
 		}),
 		regexGroupMatcher(
-			/^the cat tracker(?: (?<deviceId>[^ ]+))? fetches the next job into "(?<storeName>[^"]+)"$/,
+			/^the tracker(?: (?<deviceId>[^ ]+))? fetches the next job into "(?<storeName>[^"]+)"$/,
 		)(async ({ deviceId, storeName }, _, runner) => {
-			const catId = deviceId ?? runner.store['cat:id']
+			const catId = deviceId ?? runner.store['tracker:id']
 
 			return new Promise((resolve, reject) => {
 				const timeout = setTimeout(reject, 60 * 1000)
@@ -287,9 +287,9 @@ export const assetTrackerStepRunners = ({
 			})
 		}),
 		regexGroupMatcher(
-			/^the cat tracker(?: (?<deviceId>[^ ]+))? marks the job in "(?<storeName>[^"]+)" as in progress$/,
+			/^the tracker(?: (?<deviceId>[^ ]+))? marks the job in "(?<storeName>[^"]+)" as in progress$/,
 		)(async ({ deviceId, storeName }, _, runner) => {
-			const catId = deviceId ?? runner.store['cat:id']
+			const catId = deviceId ?? runner.store['tracker:id']
 			const job = runner.store[storeName]
 			expect(job).to.not.be.an('undefined')
 

--- a/features/CellGeolocation.feature
+++ b/features/CellGeolocation.feature
@@ -12,7 +12,7 @@ Feature: Cell Geolocation API
 
     Background:
 
-        Given I am run after the "Connect a Cat Tracker" feature
+        Given I am run after the "Connect a tracker" feature
         And I am run after the "Device: Update Shadow" feature
         And the endpoint is "{geolocationApiUrl}"
 
@@ -22,7 +22,7 @@ Feature: Cell Geolocation API
         And I store "$random() * 90" into "lat"
         And I store "$random() * 180" into "lng"
         And I store "$millis()" into "ts"
-        Then the cat tracker updates its reported state with
+        Then the tracker updates its reported state with
             """
             {
             "roam": {
@@ -42,7 +42,7 @@ Feature: Cell Geolocation API
     Scenario: Device acquires a GPS fix
 
         Given I store "$millis()+(120*1000)" into "ts"
-        Then the cat tracker updates its reported state with
+        Then the tracker updates its reported state with
             """
             {
             "gps": {

--- a/features/ConnectCatTracker.feature
+++ b/features/ConnectCatTracker.feature
@@ -1,8 +1,8 @@
-Feature: Connect a Cat Tracker
+Feature: Connect a tracker
   As a user
-  I can connect a cat tracker
+  I can Connect a tracker
 
   Scenario: Generate a certificate and connect
 
     When I generate a certificate
-    Then I connect the cat tracker
+    Then I connect the tracker

--- a/features/DeleteCats.feature
+++ b/features/DeleteCats.feature
@@ -1,18 +1,18 @@
 @Last
-Feature: Delete cats
+Feature: Delete trackers
   As a user
-  I can delete cats
+  I can delete trackers
 
   Background:
 
     Given I am authenticated with Cognito
 
-  Scenario: Delete the cat
+  Scenario: Delete the tracker
 
     When I execute "listThingPrincipals" of the AWS Iot SDK with
       """
       {
-        "thingName": "{cat:id}"
+        "thingName": "{tracker:id}"
       }
       """
     Then "$count(awsSdk.res.principals)" should equal 1
@@ -21,7 +21,7 @@ Feature: Delete cats
     Given I execute "detachThingPrincipal" of the AWS Iot SDK with
       """
       {
-        "thingName": "{cat:id}",
+        "thingName": "{tracker:id}",
         "principal": "{certificateArn}"
       }
       """
@@ -41,6 +41,6 @@ Feature: Delete cats
     And I execute "deleteThing" of the AWS Iot SDK with
       """
       {
-        "thingName": "{cat:id}"
+        "thingName": "{tracker:id}"
       }
       """

--- a/features/DeviceBatchData.feature
+++ b/features/DeviceBatchData.feature
@@ -11,7 +11,7 @@ Feature: Device: Batch Data
 
   Scenario: Devices can publish batch data
 
-    Given the cat tracker publishes this message to the topic {cat:id}/batch
+    Given the tracker publishes this message to the topic {tracker:id}/batch
       """
       {
         "gps": [
@@ -45,7 +45,7 @@ Feature: Device: Batch Data
       """
       SELECT measure_value::double AS value
       FROM "{historicaldataDatabaseName}"."{historicaldataTableName}"
-      WHERE deviceId='{cat:id}'
+      WHERE deviceId='{tracker:id}'
       AND measure_name='gps.lng'
       AND measure_value::double IS NOT NULL
       ORDER BY time DESC

--- a/features/DeviceMessages.feature
+++ b/features/DeviceMessages.feature
@@ -11,7 +11,7 @@ Feature: Device: Messages
   Scenario: Devices publishes that a button was pressed
 
     Given I store "$millis()" into "ts"
-    Then the cat tracker publishes this message to the topic {cat:id}/messages
+    Then the tracker publishes this message to the topic {tracker:id}/messages
       """
       {
       "btn": {
@@ -21,7 +21,7 @@ Feature: Device: Messages
       }
       """
     Given I store "$millis()" into "ts"
-    Then the cat tracker publishes this message to the topic {cat:id}/messages
+    Then the tracker publishes this message to the topic {tracker:id}/messages
       """
       {
       "btn": {
@@ -35,7 +35,7 @@ Feature: Device: Messages
       """
       SELECT measure_value::double AS value
       FROM "{historicaldataDatabaseName}"."{historicaldataTableName}"
-      WHERE deviceId='{cat:id}' AND measure_name='btn' AND measure_value::double IS NOT NULL
+      WHERE deviceId='{tracker:id}' AND measure_name='btn' AND measure_value::double IS NOT NULL
       ORDER BY time DESC
       """
     Then "timestreamQueryResult" should match this JSON

--- a/features/DeviceUpdateShadow.feature
+++ b/features/DeviceUpdateShadow.feature
@@ -3,12 +3,12 @@ Feature: Device: Update Shadow
 
   Background:
 
-    Given I am run after the "Connect a Cat Tracker" feature
+    Given I am run after the "Connect a tracker" feature
 
   Scenario: Publish device information to reported state
 
     Given I store "$millis()" into "updateShadowTs"
-    Then the cat tracker updates its reported state with
+    Then the tracker updates its reported state with
       """
       {
         "dev": {

--- a/features/FOTA.feature
+++ b/features/FOTA.feature
@@ -5,7 +5,7 @@ Feature: Device Firmware Upgrade over the air
 
   Background:
 
-    Given I am run after the "Connect a Cat Tracker" feature
+    Given I am run after the "Connect a tracker" feature
 
   Scenario: Create a new firmware upgrade as a user
 
@@ -40,9 +40,9 @@ Feature: Device Firmware Upgrade over the air
       """
       {
         "jobId": "{jobId}",
-        "targets": ["{cat:arn}"],
+        "targets": ["{tracker:arn}"],
         "document": {jobDocument},
-        "description": "Upgrade {cat:id} to version 1.0.1.",
+        "description": "Upgrade {tracker:id} to version 1.0.1.",
         "targetSelection": "SNAPSHOT"
       }
       """
@@ -53,7 +53,7 @@ Feature: Device Firmware Upgrade over the air
 
   Scenario: Fetch the job as a device and mark as in progress
 
-    When the cat tracker fetches the next job into "job"
+    When the tracker fetches the next job into "job"
     Then "job" should match this JSON
       """
       {
@@ -61,7 +61,7 @@ Feature: Device Firmware Upgrade over the air
         "status": "QUEUED"
       }
       """
-    And the cat tracker marks the job in "job" as in progress
+    And the tracker marks the job in "job" as in progress
 
   Scenario: describe the job
 
@@ -69,7 +69,7 @@ Feature: Device Firmware Upgrade over the air
       """
       {
         "jobId": "{jobId}",
-        "thingName": "{cat:id}"
+        "thingName": "{tracker:id}"
       }
       """
     Then "awsSdk.res.execution" should match this JSON
@@ -88,14 +88,14 @@ Feature: Device Firmware Upgrade over the air
       {
         "jobId": "{jobId}",
         "force": true,
-        "thingName": "{cat:id}"
+        "thingName": "{tracker:id}"
       }
       """
     When I execute "describeJobExecution" of the AWS Iot SDK with
       """
       {
         "jobId": "{jobId}",
-        "thingName": "{cat:id}"
+        "thingName": "{tracker:id}"
       }
       """
     Then "awsSdk.res.execution" should match this JSON
@@ -119,7 +119,7 @@ Feature: Device Firmware Upgrade over the air
       """
       {
         "jobId": "{jobId}",
-        "thingName": "{cat:id}",
+        "thingName": "{tracker:id}",
         "executionNumber": 1
       }
       """

--- a/features/FirmwareCI.feature
+++ b/features/FirmwareCI.feature
@@ -40,12 +40,12 @@ Feature: Schedule CI runs of firmware builds
         Then I store "awsSdk.res" into "ciJobReportTarget"
         And I encode "ciJobReportTarget.fields" into "ciJobReportTargetQuery" using querystring
 
-        # Create a blank new IoT thing (a regular cat with certificates generated locally)
+        # Create a blank new IoT thing (a regular tracker with certificates generated locally)
         # to be used for this specific test run.
         # The firmware is then build specifically for this device.
-        When I generate a certificate for the cat tracker "firmwaretest-{ciJobId}"
-        Then I encode "$lookup($, 'cat:firmwaretest-{ciJobId}:clientCert')" into "firmwareTestDeviceCertificatePEM" using replaceNewLines
-        And I encode "$lookup($, 'cat:firmwaretest-{ciJobId}:privateKey')" into "firmwareTestDeviceCertificatePrivateKey" using replaceNewLines
+        When I generate a certificate for the tracker "firmwaretest-{ciJobId}"
+        Then I encode "$lookup($, 'tracker:firmwaretest-{ciJobId}:clientCert')" into "firmwareTestDeviceCertificatePEM" using replaceNewLines
+        And I encode "$lookup($, 'tracker:firmwaretest-{ciJobId}:privateKey')" into "firmwareTestDeviceCertificatePrivateKey" using replaceNewLines
         And I encode "'{awsIotRootCA}'" into "awsIotRootCAEncoded" using replaceNewLines
 
         # Create a job for the AWS IoT thing used to manage the firmware CI runs
@@ -53,7 +53,7 @@ Feature: Schedule CI runs of firmware builds
             """
             {
                 "reportUrl": "{ciJobReportTarget.url}?{ciJobReportTargetQuery}",
-                "fw": "https://example.com/cat-tracker-Thingy91-ltem-debug-firmwaretest-{ciJobId}.hex",
+                "fw": "https://example.com/asset-tracker-Thingy91-ltem-debug-firmwaretest-{ciJobId}.hex",
                 "target": "thingy91_nrf9160ns:ltem",
                 "credentials": {
                     "secTag": 42,

--- a/features/ListCats.feature
+++ b/features/ListCats.feature
@@ -4,13 +4,13 @@ Feature: List cats
 
   Background:
 
-    Given I am run after the "Connect a Cat Tracker" feature
+    Given I am run after the "Connect a tracker" feature
     And I am authenticated with Cognito
 
   Scenario: The user should be able to list cats
 
     When I execute "listThings" of the AWS Iot SDK
-    Then "awsSdk.res.things[thingName='{cat:id}'].thingName" should equal this JSON
+    Then "awsSdk.res.things[thingName='{tracker:id}'].thingName" should equal this JSON
       """
-      "{cat:id}"
+      "{tracker:id}"
       """

--- a/features/QueryHistoricalData.feature
+++ b/features/QueryHistoricalData.feature
@@ -13,7 +13,7 @@ Feature: Query Data
       """
       SELECT measure_value::double AS value
       FROM "{historicaldataDatabaseName}"."{historicaldataTableName}"
-      WHERE deviceId='{cat:id}' AND measure_name='bat' AND measure_value::double IS NOT NULL LIMIT 1
+      WHERE deviceId='{tracker:id}' AND measure_name='bat' AND measure_value::double IS NOT NULL LIMIT 1
       """
     Then "timestreamQueryResult" should match this JSON
        """

--- a/features/ReadDeviceShadow.feature
+++ b/features/ReadDeviceShadow.feature
@@ -11,7 +11,7 @@ Feature: Read Device Shadow
     Given I am authenticated with Cognito
     When I execute "getThingShadow" of the AWS IotData SDK with
        """
-       {"thingName": "{cat:id}"}
+       {"thingName": "{tracker:id}"}
        """
     And I parse "awsSdk.res.payload" into "shadow"
     Then "shadow.state.reported" should match this JSON

--- a/features/UpdateDeviceConfiguration.feature
+++ b/features/UpdateDeviceConfiguration.feature
@@ -31,7 +31,7 @@ Feature: Update Device Configuration
     When I execute "updateThingShadow" of the AWS IotData SDK with
        """
        {
-         "thingName": "{cat:id}",
+         "thingName": "{tracker:id}",
          "payload": {payload}
        }
        """


### PR DESCRIPTION
This renames the cloud resources which do not
contain cat specific features (which are most of them)
to *asset tracker*.

BREAKING CHANGE: this changes the default stack name

Add this to your .envrc

    export STACK_NAME=cat-tracker

in case you wish to keep your existing installation.