### PR TITLE
test(e2e): ignore order of messages

### DIFF
--- a/features/A-GPS-fan-out.feature
+++ b/features/A-GPS-fan-out.feature
@@ -60,8 +60,8 @@ Feature: A-GPS Data Fan Out (The cargo container scenario)
       }
       """
     Then the tracker "{agpsDevice}" receives 2 raw messages on the topic {agpsDevice}/agps into "agpsData"
-    And  "agpsData[0]" should equal "(binary A-GPS data) ephemerides"
-    And  "agpsData[1]" should equal "(binary A-GPS data) other types"
+    And  "'(binary A-GPS data) ephemerides' in agpsData" should be true
+    And  "'(binary A-GPS data) other types' in agpsData" should be true
     
   Scenario: Delete tracker
   

--- a/features/A-GPS.feature
+++ b/features/A-GPS.feature
@@ -65,5 +65,5 @@ Feature: A-GPS
       }
       """
     Then the tracker receives 2 raw messages on the topic {tracker:id}/agps into "agpsData"
-    And  "agpsData[0]" should equal "(binary A-GPS data) ephemerides"
-    And  "agpsData[1]" should equal "(binary A-GPS data) other types"
+    And  "'(binary A-GPS data) ephemerides' in agpsData" should be true
+    And  "'(binary A-GPS data) other types' in agpsData" should be true


### PR DESCRIPTION
This fixes an issue with the test run which depended on the MQTT message order, which is not guaranteed.

See https://github.com/NordicSemiconductor/asset-tracker-cloud-aws-js/pull/518#pullrequestreview-720988426