### PR TITLE
feat(devices): generate devices keys on the device

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -5,7 +5,7 @@ import { IoTClient } from '@aws-sdk/client-iot'
 import { GetCallerIdentityCommand, STSClient } from '@aws-sdk/client-sts'
 import * as path from 'path'
 import { cdCommand } from './commands/cd'
-import { createDeviceCertCommand } from './commands/create-device-cert'
+import { createAndProvisionDeviceCertCommand } from './commands/create-and-provision-device-cert'
 import { reactConfigCommand } from './commands/react-config'
 import { infoCommand } from './commands/info'
 import { createCACommand } from './commands/create-ca'
@@ -19,9 +19,11 @@ import { purgeIotUserPolicyPrincipals } from './commands/purge-iot-user-policy-p
 import { purgeCAsCommand } from './commands/purge-cas'
 import { firmwareCICommand } from './commands/firmware-ci'
 import { certsDir as provideCertsDir } from './jitp/certsDir'
-import { flashCommand } from './commands/flash'
+import { flashFirmwareCommand } from './commands/flash-firmware'
 import { configureCommand } from './commands/configure'
 import { showAPIConfigurationCommand } from './commands/show-api-configuration'
+import { imeiCommand } from './commands/imei'
+import { createSimulatorCertCommand } from './commands/create-simulator-cert'
 
 const iot = new IoTClient({})
 const version = JSON.parse(
@@ -73,7 +75,7 @@ const assetTrackerCLI = async ({ isCI }: { isCI: boolean }) => {
 
 	const commands = [
 		createCACommand({ certsDir }),
-		createDeviceCertCommand({ endpoint, certsDir }),
+		createSimulatorCertCommand({ certsDir, endpoint }),
 		reactConfigCommand(),
 		infoCommand(),
 		cdCommand(),
@@ -88,9 +90,8 @@ const assetTrackerCLI = async ({ isCI }: { isCI: boolean }) => {
 		commands.push(purgeBucketsCommand(), purgeCAsCommand())
 	} else {
 		commands.push(
-			flashCommand({
-				certsDir,
-			}),
+			createAndProvisionDeviceCertCommand({ certsDir }),
+			flashFirmwareCommand(),
 			cdUpdateTokenCommand(),
 			confirm(
 				'Do you really purge all nRF Asset Tracker buckets?',
@@ -103,6 +104,7 @@ const assetTrackerCLI = async ({ isCI }: { isCI: boolean }) => {
 			firmwareCICommand({
 				endpoint,
 			}),
+			imeiCommand(),
 		)
 	}
 

--- a/cli/commands/create-and-provision-device-cert.ts
+++ b/cli/commands/create-and-provision-device-cert.ts
@@ -1,0 +1,136 @@
+import * as chalk from 'chalk'
+import { CommandDefinition } from './CommandDefinition'
+import {
+	createDeviceCertificate,
+	defaultDeviceCertificateValidityInDays,
+} from '../jitp/createDeviceCertificate'
+import {
+	atHostHexfile,
+	connect,
+	createPrivateKeyAndCSR,
+	flashCertificate,
+	getIMEI,
+} from '@nordicsemiconductor/firmware-ci-device-helpers'
+import { promises as fs } from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { deviceFileLocations } from '../jitp/deviceFileLocations'
+import { run } from '../process/run'
+import { defaultPort, defaultSecTag } from './flash-firmware'
+
+export const createAndProvisionDeviceCertCommand = ({
+	certsDir,
+}: {
+	certsDir: string
+}): CommandDefinition => ({
+	command: 'create-and-provision-device-cert',
+	options: [
+		{
+			flags: '-e, --expires <expires>',
+			description: `Validity of device certificate in days. Defaults to ${defaultDeviceCertificateValidityInDays} days.`,
+		},
+		{
+			flags: '-p, --port <port>',
+			description: `The port the device is connected to, defaults to ${defaultPort}`,
+		},
+		{
+			flags: '--dk',
+			description: `Connected device is a 9160 DK`,
+		},
+		{
+			flags: '-s, --sec-tag <secTag>',
+			description: `Use this secTag, defaults to ${defaultSecTag}`,
+		},
+		{
+			flags: '-a, --at-host <atHost>',
+			description: `Flash at_host from this file`,
+		},
+		{
+			flags: '--debug',
+			description: `Log debug messages`,
+		},
+	],
+	action: async ({ dk, expires, port, atHost, secTag, debug }) => {
+		console.log(
+			chalk.magenta(`Flashing certificate`),
+			chalk.blue(port ?? defaultPort),
+		)
+
+		const connection = await connect({
+			atHostHexfile:
+				atHost ??
+				(dk === true ? atHostHexfile['9160dk'] : atHostHexfile['thingy91']),
+			device: port ?? defaultPort,
+			warn: console.error,
+			debug: debug === true ? console.debug : undefined,
+			progress: debug === true ? console.log : undefined,
+			inactivityTimeoutInSeconds: 10,
+		})
+
+		const deviceId = await getIMEI({ at: connection.connection.at })
+
+		console.log(chalk.magenta(`IMEI`), chalk.blue(deviceId))
+
+		const csr = await createPrivateKeyAndCSR({
+			at: connection.connection.at,
+			secTag: secTag ?? defaultSecTag,
+		})
+
+		const deviceFiles = deviceFileLocations({ certsDir, deviceId })
+
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), path.sep))
+		const deviceCSRDERLocation = path.join(tempDir, `${deviceId}-csr.der`)
+
+		await fs.writeFile(deviceCSRDERLocation, csr)
+
+		// Convert to PEM
+		await run({
+			command: 'openssl',
+			args: [
+				'req',
+				'-inform',
+				'DER',
+				'-in',
+				deviceCSRDERLocation,
+				'-out',
+				deviceFiles.csr,
+			],
+		})
+
+		await createDeviceCertificate({
+			deviceId,
+			certsDir,
+			log: (...message: any[]) => {
+				console.log(...message.map((m) => chalk.magenta(m)))
+			},
+			debug: (...message: any[]) => {
+				console.log(...message.map((m) => chalk.cyan(m)))
+			},
+			daysValid: expires !== undefined ? parseInt(expires, 10) : undefined,
+		})
+		console.log(
+			chalk.green(
+				`Certificate for device ${chalk.yellow(deviceId)} generated.`,
+			),
+		)
+
+		await flashCertificate({
+			at: connection.connection.at,
+			caCert: await fs.readFile(
+				path.resolve(process.cwd(), 'data', 'AmazonRootCA1.pem'),
+				'utf-8',
+			),
+			secTag: secTag ?? defaultSecTag,
+			clientCert: await fs.readFile(deviceFiles.certWithCA, 'utf-8'),
+		})
+
+		await connection.connection.end()
+
+		console.log()
+		console.log(
+			chalk.green('Certificate written to device'),
+			chalk.blueBright(deviceId),
+		)
+	},
+	help: 'Generate a certificate for the connected device using device-generated keys, signed with the CA, and flash it to the device.',
+})

--- a/cli/commands/imei.ts
+++ b/cli/commands/imei.ts
@@ -1,0 +1,49 @@
+import * as chalk from 'chalk'
+import { CommandDefinition } from './CommandDefinition'
+import {
+	atHostHexfile,
+	connect,
+	getIMEI,
+} from '@nordicsemiconductor/firmware-ci-device-helpers'
+import { defaultPort } from './flash-firmware'
+
+export const imeiCommand = (): CommandDefinition => ({
+	command: 'imei',
+	options: [
+		{
+			flags: '-p, --port <port>',
+			description: `The port the device is connected to, defaults to ${defaultPort}`,
+		},
+		{
+			flags: '--dk',
+			description: `Connected device is a 9160 DK`,
+		},
+		{
+			flags: '-a, --at-host <atHost>',
+			description: `Flash at_host from this file`,
+		},
+		{
+			flags: '--debug',
+			description: `Log debug messages`,
+		},
+	],
+	action: async ({ dk, port, atHost, debug }) => {
+		const connection = await connect({
+			atHostHexfile:
+				atHost ??
+				(dk === true ? atHostHexfile['9160dk'] : atHostHexfile['thingy91']),
+			device: port ?? defaultPort,
+			warn: console.error,
+			debug: debug === true ? console.debug : undefined,
+			progress: debug === true ? console.log : undefined,
+		})
+
+		const imei = await getIMEI({ at: connection.connection.at })
+
+		console.log()
+		console.log(chalk.green('Connected device is'), chalk.blueBright(imei))
+
+		await connection.connection.end()
+	},
+	help: 'Prints the IMEI of the connected device',
+})

--- a/cli/jitp/createDeviceCertificate.ts
+++ b/cli/jitp/createDeviceCertificate.ts
@@ -9,20 +9,18 @@ export const defaultDeviceCertificateValidityInDays = 10950
 /**
  * Creates a certificate for a device, signed with the CA
  * @see https://docs.aws.amazon.com/iot/latest/developerguide/device-certs-your-own.html
+ *
+ * The device's CSR must already exist.
  */
 export const createDeviceCertificate = async ({
 	certsDir,
 	log,
 	debug,
 	deviceId,
-	awsIotRootCA,
-	mqttEndpoint,
 	daysValid,
 }: {
 	certsDir: string
 	deviceId: string
-	mqttEndpoint: string
-	awsIotRootCA: string
 	log?: (...message: any[]) => void
 	debug?: (...message: any[]) => void
 	daysValid?: number
@@ -38,34 +36,6 @@ export const createDeviceCertificate = async ({
 	const deviceFiles = deviceFileLocations({
 		certsDir,
 		deviceId,
-	})
-
-	await run({
-		command: 'openssl',
-		args: [
-			'ecparam',
-			'-out',
-			deviceFiles.key,
-			'-name',
-			'prime256v1',
-			'-genkey',
-		],
-		log: debug,
-	})
-
-	await run({
-		command: 'openssl',
-		args: [
-			'req',
-			'-new',
-			'-key',
-			deviceFiles.key,
-			'-out',
-			deviceFiles.csr,
-			'-subj',
-			`/CN=${deviceId}`,
-		],
-		log: debug,
 	})
 
 	await run({
@@ -97,23 +67,6 @@ export const createDeviceCertificate = async ({
 	).join(os.EOL)
 
 	await fs.writeFile(deviceFiles.certWithCA, certWithCa, 'utf-8')
-
-	// Writes the JSON file which works with the Certificate Manager of the LTA Link Monitor
-	await fs.writeFile(
-		deviceFiles.json,
-		JSON.stringify(
-			{
-				caCert: awsIotRootCA,
-				clientCert: certWithCa,
-				privateKey: await fs.readFile(deviceFiles.key, 'utf-8'),
-				clientId: deviceId,
-				brokerHostname: mqttEndpoint,
-			},
-			null,
-			2,
-		),
-		'utf-8',
-	)
 
 	return { deviceId }
 }

--- a/cli/jitp/createSimulatorKeyAndCSR.ts
+++ b/cli/jitp/createSimulatorKeyAndCSR.ts
@@ -1,0 +1,63 @@
+import { promises as fs } from 'fs'
+import { deviceFileLocations } from './deviceFileLocations'
+import { run } from '../process/run'
+
+/**
+ * Creates a private key and a CSR for a simulated device
+ */
+export const createSimulatorKeyAndCSR = async ({
+	certsDir,
+	log,
+	debug,
+	deviceId,
+}: {
+	certsDir: string
+	deviceId: string
+	log?: (...message: any[]) => void
+	debug?: (...message: any[]) => void
+}): Promise<{ deviceId: string }> => {
+	try {
+		await fs.stat(certsDir)
+	} catch {
+		throw new Error(`${certsDir} does not exist.`)
+	}
+
+	log?.(`Generating key for device ${deviceId}`)
+
+	const deviceFiles = deviceFileLocations({
+		certsDir,
+		deviceId,
+	})
+
+	await run({
+		command: 'openssl',
+		args: [
+			'ecparam',
+			'-out',
+			deviceFiles.key,
+			'-name',
+			'prime256v1',
+			'-genkey',
+		],
+		log: debug,
+	})
+
+	log?.(`Generating CSR for device ${deviceId}`)
+
+	await run({
+		command: 'openssl',
+		args: [
+			'req',
+			'-new',
+			'-key',
+			deviceFiles.key,
+			'-out',
+			deviceFiles.csr,
+			'-subj',
+			`/CN=${deviceId}`,
+		],
+		log: debug,
+	})
+
+	return { deviceId }
+}

--- a/cli/jitp/deviceFileLocations.ts
+++ b/cli/jitp/deviceFileLocations.ts
@@ -11,11 +11,11 @@ export const deviceFileLocations = ({
 	csr: string
 	cert: string
 	certWithCA: string
-	json: string
+	simulatorJSON: string
 } => ({
 	key: path.resolve(certsDir, `device-${deviceId}.key`),
 	csr: path.resolve(certsDir, `device-${deviceId}.csr`),
 	cert: path.resolve(certsDir, `device-${deviceId}.pem`),
 	certWithCA: path.resolve(certsDir, `device-${deviceId}.bundle.pem`),
-	json: path.resolve(certsDir, `device-${deviceId}.json`),
+	simulatorJSON: path.resolve(certsDir, `device-${deviceId}.json`),
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "@nordicsemiconductor/cloudformation-helpers": "6.0.41",
         "@nordicsemiconductor/e2e-bdd-test-runner": "14.3.18",
         "@nordicsemiconductor/eslint-config-asset-tracker-cloud-typescript": "8.0.7",
-        "@nordicsemiconductor/firmware-ci-device-helpers": "9.0.69",
+        "@nordicsemiconductor/firmware-ci-device-helpers": "10.2.1",
         "@nordicsemiconductor/object-to-env": "2.0.1",
         "@nordicsemiconductor/package-layered-lambdas": "7.4.66",
         "@octokit/rest": "18.9.1",
@@ -6850,13 +6850,14 @@
       }
     },
     "node_modules/@nordicsemiconductor/firmware-ci-device-helpers": {
-      "version": "9.0.69",
-      "resolved": "https://registry.npmjs.org/@nordicsemiconductor/firmware-ci-device-helpers/-/firmware-ci-device-helpers-9.0.69.tgz",
-      "integrity": "sha512-7YgctgFmLIuhZwibil9WaJHyERfS+9LJzEPgqEJ0T9ZYlXh6AzYSnYch7F7VFtwwbb895tM+W/i7b6zEgte3vg==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@nordicsemiconductor/firmware-ci-device-helpers/-/firmware-ci-device-helpers-10.2.1.tgz",
+      "integrity": "sha512-V2TCJcxXkbz2wwvuHe3h1J3hhB2ZEvwrQMg0wRfAYCaxjBuRMcefJVMSdwPRaXHGdqjxp7fbusCFZoFCGM/3uw==",
       "dev": true,
       "dependencies": {
         "@serialport/parser-readline": "9.0.7",
         "chalk": "4.1.2",
+        "semver": "7.3.5",
         "serialport": "9.2.0",
         "shell-quote": "*",
         "uuid": "8.3.2"
@@ -21745,13 +21746,14 @@
       }
     },
     "@nordicsemiconductor/firmware-ci-device-helpers": {
-      "version": "9.0.69",
-      "resolved": "https://registry.npmjs.org/@nordicsemiconductor/firmware-ci-device-helpers/-/firmware-ci-device-helpers-9.0.69.tgz",
-      "integrity": "sha512-7YgctgFmLIuhZwibil9WaJHyERfS+9LJzEPgqEJ0T9ZYlXh6AzYSnYch7F7VFtwwbb895tM+W/i7b6zEgte3vg==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/@nordicsemiconductor/firmware-ci-device-helpers/-/firmware-ci-device-helpers-10.2.1.tgz",
+      "integrity": "sha512-V2TCJcxXkbz2wwvuHe3h1J3hhB2ZEvwrQMg0wRfAYCaxjBuRMcefJVMSdwPRaXHGdqjxp7fbusCFZoFCGM/3uw==",
       "dev": true,
       "requires": {
         "@serialport/parser-readline": "9.0.7",
         "chalk": "4.1.2",
+        "semver": "7.3.5",
         "serialport": "9.2.0",
         "shell-quote": "*",
         "uuid": "8.3.2"

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@nordicsemiconductor/cloudformation-helpers": "6.0.41",
     "@nordicsemiconductor/e2e-bdd-test-runner": "14.3.18",
     "@nordicsemiconductor/eslint-config-asset-tracker-cloud-typescript": "8.0.7",
-    "@nordicsemiconductor/firmware-ci-device-helpers": "9.0.69",
+    "@nordicsemiconductor/firmware-ci-device-helpers": "10.2.1",
     "@nordicsemiconductor/object-to-env": "2.0.1",
     "@nordicsemiconductor/package-layered-lambdas": "7.4.66",
     "@octokit/rest": "18.9.1",


### PR DESCRIPTION
Modem firmware 1.3 introduced to ability to generate device
keys on the device, so that the private key never leaves
the device.

This is much more secure and therefore this is now the
recommended way to create certificates.

BREAKING CHANGE: this changes the way credentials for real devices
are generated and support for flashing device private keys from
JSON files has been removed.

Closes #546