### PR TITLE
fix: rename GPS to GNSS

### DIFF
--- a/cdk/resources/DeviceCellGeolocations.ts
+++ b/cdk/resources/DeviceCellGeolocations.ts
@@ -1,7 +1,7 @@
 import * as CloudFormation from 'aws-cdk-lib'
+import * as DynamoDB from 'aws-cdk-lib/aws-dynamodb'
 import * as IAM from 'aws-cdk-lib/aws-iam'
 import * as IoT from 'aws-cdk-lib/aws-iot'
-import * as DynamoDB from 'aws-cdk-lib/aws-dynamodb'
 
 /**
  * Store Cell Geolocation from Devices.
@@ -100,9 +100,9 @@ export class DeviceCellGeolocations extends CloudFormation.Resource {
 					'"-",',
 					'current.state.reported.roam.v.area',
 					') AS cellId,',
-					'current.state.reported.gps.v.lat AS lat,',
-					'current.state.reported.gps.v.lng AS lng,',
-					'current.state.reported.gps.v.acc AS accuracy,',
+					'current.state.reported.gnss.v.lat AS lat,',
+					'current.state.reported.gnss.v.lng AS lng,',
+					'current.state.reported.gnss.v.acc AS accuracy,',
 					'concat("device:", topic(3)) as source,',
 					"parse_time(\"yyyy-MM-dd'T'HH:mm:ss.S'Z'\", timestamp()) as timestamp",
 					`FROM '$aws/things/+/shadow/update/documents'`,
@@ -112,18 +112,18 @@ export class DeviceCellGeolocations extends CloudFormation.Resource {
 					'AND isUndefined(current.state.reported.roam.v.mccmnc) = false',
 					'AND isUndefined(current.state.reported.roam.v.cell) = false',
 					`AND isUndefined(current.state.reported.dev.v.nw) = false`,
-					// and if it has GPS location
-					'AND isUndefined(current.state.reported.gps.v.lat) = false AND current.state.reported.gps.v.lat <> 0',
-					'AND isUndefined(current.state.reported.gps.v.lng) = false AND current.state.reported.gps.v.lng <> 0',
+					// and if it has GNSS location
+					'AND isUndefined(current.state.reported.gnss.v.lat) = false AND current.state.reported.gnss.v.lat <> 0',
+					'AND isUndefined(current.state.reported.gnss.v.lng) = false AND current.state.reported.gnss.v.lng <> 0',
 					// only if the location has changed
 					'AND (',
-					'isUndefined(previous.state.reported.gps.v.lat)',
+					'isUndefined(previous.state.reported.gnss.v.lat)',
 					'OR',
-					'previous.state.reported.gps.v.lat <> current.state.reported.gps.v.lat',
+					'previous.state.reported.gnss.v.lat <> current.state.reported.gnss.v.lat',
 					'OR',
-					'isUndefined(previous.state.reported.gps.v.lng)',
+					'isUndefined(previous.state.reported.gnss.v.lng)',
 					'OR',
-					'previous.state.reported.gps.v.lng <> current.state.reported.gps.v.lng',
+					'previous.state.reported.gnss.v.lng <> current.state.reported.gnss.v.lng',
 					')',
 				].join(' '),
 				actions: [

--- a/features/CellGeolocation.feature
+++ b/features/CellGeolocation.feature
@@ -1,14 +1,14 @@
 Feature: Cell Geolocation API
 
-    GPS fixes will be stored with the cell id
+    GNSS fixes will be stored with the cell id
     so that the UI can show an approximate tracker location
-    based on the cell id even if a device has no current GPS fix
+    based on the cell id even if a device has no current GNSS fix
 
     Contexts:
 
     | nw    | nw-modem   |
-    | ltem  | LTE-M GPS  |
-    | nbiot | NB-IoT GPS |
+    | ltem  | LTE-M GNSS  |
+    | nbiot | NB-IoT GNSS |
 
     Background:
 
@@ -43,13 +43,13 @@ Feature: Cell Geolocation API
             }
             """
 
-    Scenario: Device acquires a GPS fix
+    Scenario: Device acquires a GNSS fix
 
         Given I store "$millis()+(120*1000)" into "ts"
         Then the tracker updates its reported state with
             """
             {
-            "gps": {
+            "gnss": {
             "v": {
             "lng": {lng},
             "lat": {lat},

--- a/features/DeviceBatchData.feature
+++ b/features/DeviceBatchData.feature
@@ -14,7 +14,7 @@ Feature: Device: Batch Data
     Given the tracker publishes this message to the topic {tracker:id}/batch
       """
       {
-        "gps": [
+        "gnss": [
           {
             "v": {
               "lng": {lng1},
@@ -46,7 +46,7 @@ Feature: Device: Batch Data
       SELECT measure_value::double AS value
       FROM "{historicaldataDatabaseName}"."{historicaldataTableName}"
       WHERE deviceId='{tracker:id}'
-      AND measure_name='gps.lng'
+      AND measure_name='gnss.lng'
       AND measure_value::double IS NOT NULL
       ORDER BY time DESC
       """

--- a/features/DeviceUpdateShadow.feature
+++ b/features/DeviceUpdateShadow.feature
@@ -17,7 +17,7 @@ Feature: Device: Update Shadow
             "modV": "mfw_nrf9160_1.0.0",
             "brdV": "thingy91_nrf9160",
             "appV": "0.14.6",
-            "nw": "LTE-M GPS"
+            "nw": "LTE-M GNSS"
           },
           "ts": {updateShadowTs}
         },
@@ -36,7 +36,7 @@ Feature: Device: Update Shadow
           "actwt": 60,
           "mvres": 60,
           "mvt": 3600,
-          "gpst": 1000,
+          "gnsst": 1000,
           "acct": 0.5
         }
       }

--- a/features/NeighborCellMeasurementsStorage.feature
+++ b/features/NeighborCellMeasurementsStorage.feature
@@ -17,7 +17,7 @@ Feature: Store neighboring cell measurement reports
             {
             "dev": {
                 "v": {
-                    "nw": "LTE-M GPS"
+                    "nw": "LTE-M GNSS"
                 },
                 "ts": {ts}
             },
@@ -136,7 +136,7 @@ Feature: Store neighboring cell measurement reports
                 "ts": { "N": "{ts}" }
             }
             },
-            "nw": { "S": "LTE-M GPS" },
+            "nw": { "S": "LTE-M GNSS" },
             "deviceId": { "S": "{tracker:id}" }
         }
         """

--- a/features/ReadDeviceShadow.feature
+++ b/features/ReadDeviceShadow.feature
@@ -23,7 +23,7 @@ Feature: Read Device Shadow
               "modV": "mfw_nrf9160_1.0.0",
               "brdV": "thingy91_nrf9160",
               "appV": "0.14.6",
-              "nw": "LTE-M GPS"
+              "nw": "LTE-M GNSS"
             },
             "ts": {updateShadowTs}
          },
@@ -43,7 +43,7 @@ Feature: Read Device Shadow
             "actwt": 60,
             "mvres": 60,
             "mvt": 3600,
-            "gpst": 1000,
+            "gnsst": 1000,
             "acct": 0.5
           }
        }

--- a/features/UpdateDeviceConfiguration.feature
+++ b/features/UpdateDeviceConfiguration.feature
@@ -20,7 +20,7 @@ Feature: Update Device Configuration
                 "actwt": 60,
                 "mvres": 60,
                 "mvt": 3600,
-                "gpst": 1000,
+                "gnsst": 1000,
                 "acct": 0.5
               }
             }

--- a/historicalData/batchToTimestreamRecords.spec.ts
+++ b/historicalData/batchToTimestreamRecords.spec.ts
@@ -12,7 +12,7 @@ describe('batchToTimestreamRecords', () => {
 		]
 		const r = batchToTimestreamRecords({
 			batch: {
-				gps: [
+				gnss: [
 					{
 						v: {
 							lng: 8.669555,
@@ -42,28 +42,28 @@ describe('batchToTimestreamRecords', () => {
 		expect(r).toEqual([
 			{
 				Dimensions,
-				MeasureName: 'gps.lng',
+				MeasureName: 'gnss.lng',
 				MeasureValue: '8.669555',
 				MeasureValueType: 'DOUBLE',
 				Time: '1606483136657',
 			},
 			{
 				Dimensions,
-				MeasureName: 'gps.lat',
+				MeasureName: 'gnss.lat',
 				MeasureValue: '50.109177',
 				MeasureValueType: 'DOUBLE',
 				Time: '1606483136657',
 			},
 			{
 				Dimensions,
-				MeasureName: 'gps.lng',
+				MeasureName: 'gnss.lng',
 				MeasureValue: '10.424793',
 				MeasureValueType: 'DOUBLE',
 				Time: '1606483256659',
 			},
 			{
 				Dimensions,
-				MeasureName: 'gps.lat',
+				MeasureName: 'gnss.lat',
 				MeasureValue: '63.422975',
 				MeasureValueType: 'DOUBLE',
 				Time: '1606483256659',

--- a/historicalData/shadowUpdateToTimestreamRecords.spec.ts
+++ b/historicalData/shadowUpdateToTimestreamRecords.spec.ts
@@ -17,7 +17,7 @@ describe('shadowUpdateToTimestreamRecords', () => {
 					actwt: 60,
 					mvres: 300,
 					mvt: 3600,
-					gpst: 60,
+					gnsst: 60,
 					acct: 0.5,
 				},
 				dev: {

--- a/historicalData/types.d.ts
+++ b/historicalData/types.d.ts
@@ -21,7 +21,7 @@ type UpdatedDeviceState = {
 		bat?: NumberValueSensor
 		env?: NumbersValueSensor
 		acc?: NumbersValueSensor
-		gps?: NumbersValueSensor
+		gnss?: NumbersValueSensor
 		dev?: NumbersAndStringsValueSensor
 		roam?: NumbersAndStringsValueSensor
 	}
@@ -44,7 +44,7 @@ type BatchMessage = {
 		bat?: NumberValueSensor[]
 		env?: NumbersValueSensor[]
 		acc?: NumbersValueSensor[]
-		gps?: NumbersValueSensor[]
+		gnss?: NumbersValueSensor[]
 		dev?: NumbersAndStringsValueSensor[]
 		roam?: NumbersAndStringsValueSensor[]
 	}


### PR DESCRIPTION
The more generic term GNSS is used in favor of GPS.

See https://github.com/NordicSemiconductor/asset-tracker-cloud-docs/pull/352

BREAKING CHANGE: this requires firmware updates